### PR TITLE
Fix regression variable names

### DIFF
--- a/House_Sales_in_King_Count_USA.ipynb
+++ b/House_Sales_in_King_Count_USA.ipynb
@@ -1405,11 +1405,11 @@
     }
    ],
    "source": [
-    "x = df[['sqft_living']]\n",
+    "X = df[['sqft_living']]\n",
     "y = df[['price']]\n",
     "lm = LinearRegression()\n",
-    "lm.fit(x,y)\n",
-    "lm.score(x,y)"
+    "lm.fit(X,y)\n",
+    "lm.score(X,y)"
    ]
   },
   {
@@ -1461,8 +1461,8 @@
     "X = df[[\"floors\", \"waterfront\",\"lat\" ,\"bedrooms\" ,\"sqft_basement\" ,\"view\" ,\"bathrooms\",\"sqft_living15\",\"sqft_above\",\"grade\",\"sqft_living\"]]\n",
     "y = df[\"price\"]\n",
     "lm = LinearRegression()\n",
-    "lm.fit(x, y)\n",
-    "lm.score(x, y)"
+    "lm.fit(X, y)\n",
+    "lm.score(X, y)"
    ]
   },
   {
@@ -1528,8 +1528,8 @@
    ],
    "source": [
     "pipe = Pipeline(Input)\n",
-    "pipe.fit(x, y)\n",
-    "pipe.score(x, y)"
+    "pipe.fit(X, y)\n",
+    "pipe.score(X, y)"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- update regression cells in `House_Sales_in_King_Count_USA.ipynb` to use `X` instead of `x`
- adjust pipeline section to train using `X`

## Testing
- `jupyter nbconvert --to notebook --execute House_Sales_in_King_Count_USA.ipynb --stdout` *(fails: dataset fetch blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6865ff9c3d98832397c18933bbbb3535